### PR TITLE
Fix artist error message rendering

### DIFF
--- a/src/music/Music.jsx
+++ b/src/music/Music.jsx
@@ -484,7 +484,7 @@ export function ArtistExplorer() {
             {
                 spotifyError != null && <div className="SpotifyError">
                     <h1>Spotify Error</h1>
-                    <p>{spotifyError}</p>
+                    <p>{spotifyError.message}</p>
                 </div>
             }
             {artist != null && <>


### PR DESCRIPTION
## Summary
- fix SpotifyError display in artist page

## Testing
- `npm run lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684680075f7c832b83c1f05b6364b674